### PR TITLE
Fix order of 2d indexed point

### DIFF
--- a/liblzr/src/ilda.h
+++ b/liblzr/src/ilda.h
@@ -58,8 +58,8 @@ typedef struct {
 typedef struct {
     int16_t     x;
     int16_t     y;
-    uint8_t     color;
     ilda_status status;
+    uint8_t     color;
 } ilda_point_2d_indexed;
 
 


### PR DESCRIPTION
Hello Brendan,

Please check "5.1.2. Format 1 – 2D Coordinates with Indexed Color" section of ILDA format specification:
http://www.ilda.com/resources/StandardsDocs/ILDA_IDTF14_rev011.pdf

The correct ilda_point_2d_indexed fields order is X, Y, status, color.

Thank you for the library, it is very useful.

Best regards,
Sergey
