### PR TITLE
Windows port

### DIFF
--- a/liblzr/liblzr.h
+++ b/liblzr/liblzr.h
@@ -21,6 +21,14 @@
 
 #define LZR_VERSION "0.0.1"
 
+// Windows dll export symbols
+#ifdef _WIN32
+#define LIBLZR_EXPORT __declspec(dllexport)
+#else
+#define LIBLZR_EXPORT
+#endif
+
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <vector>
@@ -52,7 +60,7 @@ namespace lzr {
 #define LZR_COLOR_MAX    255
 
 
-class Point
+class LIBLZR_EXPORT Point
 {
 public:
     double x;  //Position X   [-1.0, 1.0]
@@ -68,8 +76,8 @@ public:
 
     void blank();
     void unblank();
-    bool is_blanked();
-    bool is_lit();
+    bool is_blanked() const;
+    bool is_lit() const;
     Point lerp_to(const Point& other, double t) const;
     double sq_distance_to(const Point& other) const;
     bool same_position_as(const Point& other) const;
@@ -86,7 +94,7 @@ public:
 
 //OK as long as the Frame class doesn't save any state, which, it shouldn't...
 //this is only a convenient way to attach functions to the type
-class Frame : public std::vector<Point>
+class LIBLZR_EXPORT Frame : public std::vector<Point>
 {
 public:
     Frame();
@@ -118,13 +126,13 @@ typedef std::vector<Frame> FrameList;
 /*  LZR Frame Transforms                                                      */
 /******************************************************************************/
 
-int translate(Frame& frame, double x, double y);
-int rotate(Frame& frame, Point center, double theta);
-int scale(Frame& frame, Point center, double x, double y);
-int mirror(Frame& frame, Point center, bool x, bool y);
-int dup_mirror(Frame& frame, Point center, bool x, bool y, bool blank=true);
-int dup_linear(Frame& frame, Point offset, size_t n_dups, bool blank=true);
-int dup_radial(Frame& frame, Point center, size_t n_dups, double angle, bool blank=true);
+LIBLZR_EXPORT int translate(Frame& frame, double x, double y);
+LIBLZR_EXPORT int rotate(Frame& frame, Point center, double theta);
+LIBLZR_EXPORT int scale(Frame& frame, Point center, double x, double y);
+LIBLZR_EXPORT int mirror(Frame& frame, Point center, bool x, bool y);
+LIBLZR_EXPORT int dup_mirror(Frame& frame, Point center, bool x, bool y, bool blank=true);
+LIBLZR_EXPORT int dup_linear(Frame& frame, Point offset, size_t n_dups, bool blank=true);
+LIBLZR_EXPORT int dup_radial(Frame& frame, Point center, size_t n_dups, double angle, bool blank=true);
 
 
 //clips a frame using the given mask. Points in the mask should define a closed
@@ -143,9 +151,9 @@ int dup_radial(Frame& frame, Point center, size_t n_dups, double angle, bool bla
 typedef double (*interpolation_func)(double t);
 
 //interpolation functions
-double linear(double t); /*----*----*----*----*----*----*----*----*/
-double quad(double t);   /*---*---*-----*-----*-----*-----*---*---*/
-double quart(double t);  /*-*---*-----*-------*-------*-----*---*-*/
+LIBLZR_EXPORT double linear(double t); /*----*----*----*----*----*----*----*----*/
+LIBLZR_EXPORT double quad(double t);   /*---*---*-----*-----*-----*-----*---*---*/
+LIBLZR_EXPORT double quart(double t);  /*-*---*-----*-------*-------*-----*---*-*/
 
 
 //100 points from one side of the frame to the other
@@ -153,7 +161,7 @@ double quart(double t);  /*-*---*-----*-------*-------*-----*---*-*/
 
 //main interpolator function
 //Only interpolates lit points. Use the Optimizer to interpolate blanking jumps
-int interpolate(Frame& frame,
+LIBLZR_EXPORT int interpolate(Frame& frame,
                 double max_distance=INTERP_DEFAULT,
                 interpolation_func func=linear);
 
@@ -169,7 +177,7 @@ int interpolate(Frame& frame,
 //fwrd decl
 class Optimizer_Internals;
 
-class Optimizer
+class LIBLZR_EXPORT Optimizer
 {
 public:
     Optimizer();
@@ -202,22 +210,22 @@ class ILDA;
 // "r" = read
 // "w" = write
 //Will return NULL on failure
-ILDA* ilda_open(const char* filename, const char* mode);
+LIBLZR_EXPORT ILDA* ilda_open(const char* filename, const char* mode);
 
 //closes the ILDA file, and releases the parsing context
-void ilda_close(ILDA* f);
+LIBLZR_EXPORT void ilda_close(ILDA* f);
 
 //Reads all frames for the the given projector, and returns them
-int ilda_read(ILDA* f, size_t pd, FrameList& frame_list);
+LIBLZR_EXPORT int ilda_read(ILDA* f, size_t pd, FrameList& frame_list);
 
 //write frame(s) for the given projector to the ILDA file (file must be opened with lzr_ilda_write() )
-int ilda_write(ILDA* f, size_t pd, FrameList& frame_list);
+LIBLZR_EXPORT int ilda_write(ILDA* f, size_t pd, FrameList& frame_list);
 
 //returns the number of projectors that the ILDA specifies graphics for
-size_t ilda_projector_count(ILDA* f);
+LIBLZR_EXPORT size_t ilda_projector_count(ILDA* f);
 
 //returns the number of frames for the given projector descriptor
-size_t ilda_frame_count(ILDA* f, size_t pd);
+LIBLZR_EXPORT size_t ilda_frame_count(ILDA* f, size_t pd);
 
 
 

--- a/liblzr/src/ilda.h
+++ b/liblzr/src/ilda.h
@@ -4,8 +4,9 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <endian.h>
 #include <liblzr.h>
+
+#include "include/portable_endian.h"
 
 namespace lzr {
 

--- a/liblzr/src/include/portable_endian.h
+++ b/liblzr/src/include/portable_endian.h
@@ -1,0 +1,120 @@
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to. This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#	define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#	include <endian.h>
+
+#elif defined(__APPLE__)
+
+#	include <libkern/OSByteOrder.h>
+
+#	define htobe16(x) OSSwapHostToBigInt16(x)
+#	define htole16(x) OSSwapHostToLittleInt16(x)
+#	define be16toh(x) OSSwapBigToHostInt16(x)
+#	define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#	define htobe32(x) OSSwapHostToBigInt32(x)
+#	define htole32(x) OSSwapHostToLittleInt32(x)
+#	define be32toh(x) OSSwapBigToHostInt32(x)
+#	define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#	define htobe64(x) OSSwapHostToBigInt64(x)
+#	define htole64(x) OSSwapHostToLittleInt64(x)
+#	define be64toh(x) OSSwapBigToHostInt64(x)
+#	define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#	include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#	include <sys/endian.h>
+
+#	define be16toh(x) betoh16(x)
+#	define le16toh(x) letoh16(x)
+
+#	define be32toh(x) betoh32(x)
+#	define le32toh(x) letoh32(x)
+
+#	define be64toh(x) betoh64(x)
+#	define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#	include <winsock2.h>
+#ifndef _MSC_VER
+#	include <sys/param.h>
+#endif
+
+#	if BYTE_ORDER == LITTLE_ENDIAN
+
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
+
+#	elif BYTE_ORDER == BIG_ENDIAN
+
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#	error platform not supported
+
+#endif
+
+#endif

--- a/liblzr/src/point.cpp
+++ b/liblzr/src/point.cpp
@@ -64,12 +64,12 @@ void Point::unblank()
     i = 255;
 }
 
-bool Point::is_blanked()
+bool Point::is_blanked() const
 {
     return (i == 0) || (r + g + b == 0);
 }
 
-bool Point::is_lit()
+bool Point::is_lit() const
 {
     return (i > 0) && (r + g + b > 0);
 }


### PR DESCRIPTION
Hello Brendan,

I used your library in the proprietary project on Mac/Windows. MSVC doesn't have <endian.h> include so I was forced to add portable version of endian.h from https://gist.github.com/panzi/6856583 with minimal changes. It works well.

Also I fixed some const methods.

* Add dll export directives. I didn't export DAC class because it depends on etherdream (unix-only?).
* Add portable_endian.h. 
* Fix const-correctness for some lzr::Point class functions


Please review the changes and let me know if something is not ok, I'll fix it.

Thank you,
Sergey