### PR TITLE
Update optimizer_find_paths.cpp

### DIFF
--- a/liblzr/src/optimizer_find_paths.cpp
+++ b/liblzr/src/optimizer_find_paths.cpp
@@ -84,7 +84,7 @@ void OptimizerInternals::path_split(float split_angle)
             if(in_path)
             {
                 //test the angle this point makes with previous/next points
-                if( (i+1 < paths.size()) && points[i+1].is_lit() ) //is the next point valid to check against
+                if( (i+1 < points.size()) && points[i+1].is_lit() ) //is the next point valid to check against
                 {
                     Optimizer_Point next = points[i + 1];
 


### PR DESCRIPTION
paths.size() will always be equal to zero because path is cleared at the beginning of the path_split member function and the only part of the loop that add to paths is under that condition that test that (i+1 < paths.size()) therefore the code from line 88 to 99 will never be executed