### PR TITLE
Allow to read ILD files from plain data

### DIFF
--- a/liblzr/liblzr.hpp
+++ b/liblzr/liblzr.hpp
@@ -240,6 +240,10 @@ class ILDA;
 //Will return NULL on failure
 LIBLZR_EXPORT ILDA* ilda_open(const char* filename, const char* mode);
 
+// Read ILDA from plain data
+//Will return NULL on failure
+LIBLZR_EXPORT ILDA* ilda_open(const char* data, size_t size);
+
 //closes the ILDA file, and releases the parsing context
 LIBLZR_EXPORT int ilda_close(ILDA* f);
 

--- a/liblzr/src/ilda.hpp
+++ b/liblzr/src/ilda.hpp
@@ -167,6 +167,11 @@ class ILDA
 
         FILE* f;     // the current file
         bool read;   // if false, we're in write mode
+
+        const char* data; // data
+        size_t data_size; // data size
+        size_t data_index; // data current index
+
         const char* error; // error string
 
         ILDA_Projector* current_projector();


### PR DESCRIPTION
Hello Brendan,

Here is a small improvement that allows to read ILD directly from memory without files on disk, it's necessary sometimes in LaserOS app (core part of the app is a GPL-library [ldCore](https://github.com/Wickedlasers/libLaserdockCore), liblzr is [a part](https://github.com/Wickedlasers/libLaserdockCore/tree/master/3rdparty/liblzr) of it). 

I'm not sure if name ilda_open is ok, please let me know if it's better to rename it, maybe ilda_open_buffer or something like this.

Also just FYI we use a small [Cmake file](https://github.com/Wickedlasers/libLaserdockCore/blob/master/3rdparty/liblzr/CMakeLists.txt) to build required parts of liblzr on different platforms. You can adjust it to build your lzr library with cmake, cmake is nice :)

Thank you,
Sergey